### PR TITLE
Remove unneeded part of regex

### DIFF
--- a/lib/twitter_username_extractor.rb
+++ b/lib/twitter_username_extractor.rb
@@ -13,7 +13,7 @@ module TwitterUsernameExtractor
     return Regexp.last_match(1) if t.match(%r{twitter.com/search\?q=%23(\w+)}i)
     return Regexp.last_match(1) if t.match(%r{twitter.com/#!/https://twitter.com/(\w+)}i)
     return Regexp.last_match(1) if t.match(%r{(?:www.)?twitter.com/#!/(\w+)[/\?]?}i)
-    return Regexp.last_match(1) if t.match(%r{(?:www.)?twitter.com/@?(\w+)[/\/]?}i)
+    return Regexp.last_match(1) if t.match(%r{(?:www.)?twitter.com/@?(\w+)[\/]?}i)
     fail Error, "Unknown twitter handle: #{t}"
   end
 end


### PR DESCRIPTION
Just noticed this when running the tests on a project using this gem and though I'd do a drive by fix.

There was an extra `/` in the regex to match one of the known types of Twitter urls. This was resulting in a warning (see https://github.com/everypolitician/twitter_username_extractor/issues/1 for details) when the library was required.

Fixes #1 
